### PR TITLE
DTSPO-12719 Add orphaned resource cleanup automation

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,8 +12,10 @@ schedules:
         - master
     always: 'true'
 
-parameters:
+variables:
+  isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
 
+parameters:
   - name: ado_pipelines
     type: object
     default:
@@ -159,3 +161,22 @@ jobs:
           targetType: filePath
           filePath: scripts/send-slack-message.sh
           arguments: $(slack-webhook-url) dtspo-bau
+  - job: OrphanResourceCleanup
+    # Only run on master branch
+    condition: eq(variables.isMaster, true)
+    pool:
+      name: 'hmcts-cftptl-agent-pool'
+    steps:
+      - task: AzureKeyVault@1
+        displayName: 'Get secrets from Keyvault'
+        inputs:
+          azureSubscription:  "DTS-CFTPTL-INTSVC"
+          keyVaultName:   "cftptl-intsvc"
+          secretsFilter: 'orphaned-resources-slack-webhook'
+      - task: Bash@3
+        displayName: 'Deleting orphaned resources in Azure'
+        inputs:
+          targetType: filePath
+          filePath: scripts/orphan-cleanup.sh
+          arguments: $(orphaned-resources-slack-webhook) dtspo-orphaned-resource-cleanup
+

--- a/scripts/orphan-cleanup.sh
+++ b/scripts/orphan-cleanup.sh
@@ -1,0 +1,58 @@
+# Orphan Resources queries obtained from Orphan Resources Workbook
+# available at https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/platopsmonitor_test/providers/microsoft.insights/workbooks/03553b7d-6be1-459a-b747-7c69e21f5cb3/workbook
+WEBHOOK_URL=$1
+SLACK_CHANNEL_NAME=$2
+
+resources_to_delete=()
+failed_to_delete=()
+orphan_queries=(
+    # Load Balancers
+    'resources | where type == "microsoft.network/loadbalancers" | where properties.backendAddressPools == "[]" '
+    # App Service Plans
+    'resources | where type =~ "microsoft.web/serverfarms" | where properties.numberOfSites == 0'
+    # Route Tables
+    'resources | where type == "microsoft.network/routetables" | where isnull(properties.subnets)'
+    # Availability Sets
+    'resources | where type =~ "Microsoft.Compute/availabilitySets" | where properties.virtualMachines == "[]"'
+    # NSGs
+    'resources | where type == "microsoft.network/networksecuritygroups" and isnull(properties.networkInterfaces) and isnull(properties.subnets)'
+    # Resource Groups
+    'ResourceContainers | where type == "microsoft.resources/subscriptions/resourcegroups" | extend rgAndSub = strcat(resourceGroup, "--", subscriptionId) | join kind=leftouter (Resources | extend rgAndSub = strcat(resourceGroup, "--", subscriptionId) | summarize count() by rgAndSub) on rgAndSub | where isnull(count_)'
+    # Public IPs
+    'resources | where type == "microsoft.network/publicipaddresses" | where properties.ipConfiguration == ""'
+    #  Network Interfaces
+    'resources | where type has "microsoft.network/networkinterfaces" | where isnull(properties.privateEndpoint) | where isnull(properties.privateLinkService) | where properties !has "virtualmachine"'
+    # Disks
+    'resources | where type has "microsoft.compute/disks" | extend diskState = tostring(properties.diskState) | where managedBy == "" | where not(name endswith "-ASRReplica" or name startswith "ms-asr-")'
+)
+
+# Graph query to fetch orphaned Resource IDs 
+for query in "${orphan_queries[@]}"
+do
+  resources_to_delete+=$(az graph query -q "$query" | jq '.data[].id')
+done
+
+# Solves problem of some resource ID's not having space between them in jq output
+resources_to_delete=$(sed 's/""/" "/g' <<< $resources_to_delete)
+
+# Convert into array to loop over resources and sequentially (to record failures) delete them
+resources_to_delete=($resources_to_delete)
+for resource in "${resources_to_delete[@]:0:5}"
+do
+  # Trim " from resource, as az command also wraps with '
+  resource=$(echo $resource | tr -d '"')
+  echo "Attemping delete of: $resource\n"
+  # Check if resource should be ignored by this automation, based on tag ignoredByOrphanCleanup: true
+  ignoreResource=$(az resource show --ids $resource | jq '.tags.ignoredByOrphanCleanup')
+  if [[ "$ignoreResource" =~ "true" ]] ; then
+    echo "Skipping $resource as it is tagged."
+  else
+    if az resource delete --ids $resource ; then
+      echo "Successfully deleted!"
+    else
+      failed_to_delete+=$resource
+      echo "Deletion failed, to see why this occured please run: az resource delete --ids $resource --verbose"
+    fi
+  fi
+done
+#  Check length of failed_to_delete=(), if > 0 , send slack message below


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-13719

There is no nice way seemingly to export all of the graph queries running that create a workbook in azure, so I've taken each independent query and added it to this script.
AZ-CLI also has hard limit of 1000 return results per query, so I chose to keep these as separate queries rather than go down pagination route and add complexity. It also makes it simpler to add/remove queries in future.

The script has added functionality to check for existence of a tag before trying to delete a resource.
Build should only be possible from main branch, which runs on a schedule.

Left room and functionality for adding slack messages in quick PR after this, as part of another story.


Workbook for reference: https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/platopsmonitor_test/providers/microsoft.insights/workbooks/03553b7d-6be1-459a-b747-7c69e21f5cb3/workbook

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
