### PR TITLE
Cluster state check

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -203,6 +203,12 @@ jobs:
           targetType: filePath
           filePath: scripts/jenkins-status.sh
           arguments: $(jenkins-api-user) $(jenkins-api-token) ${{ variables.jenkins_url }}
+      - task: AzureCLI@2
+          displayName: 'Get AKS Cluster State'
+          inputs:
+            scriptType: bash
+            scriptPath: scripts/cluster-state-monitor.sh
+            azureSubscription: ${{ variables.ado_service_connection }}
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -203,12 +203,6 @@ jobs:
           targetType: filePath
           filePath: scripts/jenkins-status.sh
           arguments: $(jenkins-api-user) $(jenkins-api-token) ${{ variables.jenkins_url }}
-      - task: AzureCLI@2
-          displayName: 'Get AKS Cluster State'
-          inputs:
-            scriptType: bash
-            scriptPath: scripts/cluster-state-monitor.sh
-            azureSubscription: ${{ variables.ado_service_connection }}
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -201,6 +201,11 @@ jobs:
           targetType: filePath
           filePath: scripts/jenkins-status.sh
           arguments: $(jenkins-api-user) $(jenkins-api-token) ${{ variables.jenkins_url }}
+      - task: AzureCLI@2
+          displayName: 'Get AKS Cluster State'
+          inputs:
+            scriptType: bash
+            scriptPath: scripts/cluster-state-monitor.sh
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -209,6 +209,7 @@ jobs:
             scriptType: bash
             scriptPath: scripts/cluster-state-monitor.sh
             azureSubscription: ${{ variables.ado_service_connection }}
+            arguments: ${{ variables.SPSecretNumDays }}
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -141,7 +141,7 @@ variables:
   - name: service_connection
     value: dts-management-prod-intsvc
   - name: ado_service_connection
-    value: dcd_sp_ado_mgmt_operations_v2
+    value: HMCTS-RAPID7-NONPROD-INTSVC
   - name: isMain
     value: $[in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/master')]
   - name: isAutoTriggered

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -140,6 +140,8 @@ variables:
     value: 14
   - name: service_connection
     value: dts-management-prod-intsvc
+  - name: ado_service_connection
+    value: dcd_sp_ado_mgmt_operations_v2
   - name: isMain
     value: $[in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/master')]
   - name: isAutoTriggered
@@ -206,6 +208,7 @@ jobs:
           inputs:
             scriptType: bash
             scriptPath: scripts/cluster-state-monitor.sh
+            azureSubscription: ${{ variables.ado_service_connection }}
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -204,12 +204,11 @@ jobs:
           filePath: scripts/jenkins-status.sh
           arguments: $(jenkins-api-user) $(jenkins-api-token) ${{ variables.jenkins_url }}
       - task: AzureCLI@2
-          displayName: 'Get AKS Cluster State'
-          inputs:
-            scriptType: bash
-            scriptPath: scripts/cluster-state-monitor.sh
-            azureSubscription: ${{ variables.ado_service_connection }}
-            arguments: ${{ variables.SPSecretNumDays }}
+        displayName: 'Get Provisioning State'
+        inputs:
+          scriptType: bash
+          scriptPath: scripts/cluster-state-monitor.sh
+          azureSubscription: ${{ variables.ado_service_connection }}
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -141,7 +141,7 @@ variables:
   - name: service_connection
     value: dts-management-prod-intsvc
   - name: ado_service_connection
-    value: HMCTS-RAPID7-NONPROD-INTSVC
+    value: OPS-APPROVAL-GATE-MGMT-ENVS
   - name: isMain
     value: $[in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/master')]
   - name: isAutoTriggered

--- a/scripts/aks-node-count.sh
+++ b/scripts/aks-node-count.sh
@@ -26,7 +26,7 @@ PERCENTAGE=$((100*$NODE_COUNT/$MAX_COUNT))
 
 CLUSTER_URL="https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.ContainerService/managedClusters/$CLUSTER_NAME/overview"
 
-printf "\n:aks: <$CLUSTER_URL|_*Cluster $CLUSTER_NAME Status*_>  \n\n" >> slack-message.txt
+printf "\n\n:aks: <$CLUSTER_URL|_*Cluster $CLUSTER_NAME Status*_>  \n\n" >> slack-message.txt
 if [ $PERCENTAGE -gt 95 ]; then
     echo "> :red_circle: _*$CLUSTER_NAME*_ is running above 95% capacity at *$PERCENTAGE%*" >> slack-message.txt
 elif [ $PERCENTAGE -gt 80 ]; then

--- a/scripts/cluster-state-monitor.sh
+++ b/scripts/cluster-state-monitor.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#Vars
+
+printf "\n:aks: *Cluster State Check*" >> slack-message.txt
+
+SUBSCRIPTIONS=$(az account list -o json)
+while read subscription; do
+    SUBSCRIPTION_ID=$(jq -r '.id' <<< $subscription)
+    az account set -s $SUBSCRIPTION_ID
+    #CLUSTERS=$(az resource list --resource-type Microsoft.ContainerService/managedClusters --query "[?tags.application == 'core']" -o json)
+    CLUSTERS=$(az resource list --resource-type Microsoft.ContainerService/managedClusters -o json)
+
+while read cluster; do
+    RESOURCE_GROUP=$(jq -r '.resourceGroup' <<< $cluster)
+    cluster_name=$(jq -r '.name' <<< $cluster)
+
+    cluster_data=$(az aks show -n $cluster_name -g $RESOURCE_GROUP -o json)
+    cluster_status=$(jq -r '.provisioningState' <<< "$cluster_data")
+    cluster_id=$(jq -r '.id' <<< "$cluster_data")
+
+    if [[ $cluster_status == "Failed" ]]; then
+        printf "\n>:red_circle:  <https://portal.azure.com/#@HMCTS.NET/resource$cluster_id|_*$cluster_name*_> has a provisioning state of $cluster_status" >> slack-message.txt
+        failures_exist="true"
+    fi
+done < <(jq -c '.[]' <<< $CLUSTERS) # end_of_cluster_loop
+
+done < <(jq -c '.[]' <<< $SUBSCRIPTIONS)
+
+if [[ $failures_exist != "true" ]]; then
+    printf "\n>:green_circle:  All clusters have a provisioning state of: Succeeded" >> slack-message.txt
+fi
+

--- a/scripts/cluster-state-monitor.sh
+++ b/scripts/cluster-state-monitor.sh
@@ -6,8 +6,7 @@ SUBSCRIPTIONS=$(az account list -o json)
 while read subscription; do
     SUBSCRIPTION_ID=$(jq -r '.id' <<< $subscription)
     az account set -s $SUBSCRIPTION_ID
-    #CLUSTERS=$(az resource list --resource-type Microsoft.ContainerService/managedClusters --query "[?tags.application == 'core']" -o json)
-    CLUSTERS=$(az resource list --resource-type Microsoft.ContainerService/managedClusters -o json)
+    CLUSTERS=$(az resource list --resource-type Microsoft.ContainerService/managedClusters --query "[?tags.application == 'core']" -o json)
 
 while read cluster; do
     RESOURCE_GROUP=$(jq -r '.resourceGroup' <<< $cluster)

--- a/scripts/cluster-state-monitor.sh
+++ b/scripts/cluster-state-monitor.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #Vars
-test=$1
-
 printf "\n:aks: *Cluster State Check*" >> slack-message.txt
 
 SUBSCRIPTIONS=$(az account list -o json)

--- a/scripts/cluster-state-monitor.sh
+++ b/scripts/cluster-state-monitor.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #Vars
+test=$1
 
 printf "\n:aks: *Cluster State Check*" >> slack-message.txt
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-14690](https://tools.hmcts.net/jira/browse/DTSPO-14690)


### Change description ###
- Adding script to monitor the provisioning state of all clusters tagged as "core"
- Specific cluster names will only appear if there is a failed state to avoid noise in channel.

**With errors**: (these clusters included to demonstrate a failed state)
<img width="452" alt="Screenshot 2023-07-28 at 15 50 18" src="https://github.com/hmcts/dtspo-daily-monitoring/assets/125922012/43041f1f-fd7f-405b-9a61-0505e927571c">

**without errors**:
<img width="422" alt="Screenshot 2023-07-28 at 16 00 22" src="https://github.com/hmcts/dtspo-daily-monitoring/assets/125922012/c5b0ebc3-31e8-4bbb-9724-12f63f530178">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```



