### PR TITLE
Check dev tenant service principals

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -179,7 +179,7 @@ variables:
   - name: service_connection
     value: dts-management-prod-intsvc
   - name: dev_service_connection
-    value: dts-terraform-prod-test1
+    value: GA-development-tenant
   - name: ado_service_connection
     value: OPS-APPROVAL-GATE-MGMT-ENVS
   - name: isMain

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -178,6 +178,8 @@ variables:
     value: 14
   - name: service_connection
     value: dts-management-prod-intsvc
+  - name: dev_service_connection
+    value: dts-terraform-prod-test1
   - name: ado_service_connection
     value: OPS-APPROVAL-GATE-MGMT-ENVS
   - name: isMain
@@ -308,6 +310,13 @@ jobs:
           scriptType: bash
           scriptPath: scripts/service-principals.sh
           azureSubscription: ${{ variables.service_connection }}
+          arguments: ${{ variables.SPSecretNumDays }}
+      - task: AzureCLI@2
+        displayName: 'Service Principal Check - Dev Tenant'
+        inputs:
+          scriptType: bash
+          scriptPath: scripts/service-principals.sh
+          azureSubscription: ${{ variables.dev_service_connection }}
           arguments: ${{ variables.SPSecretNumDays }}
       - task: Bash@3
         displayName: 'Checking JIRA status'

--- a/scripts/service-principals.sh
+++ b/scripts/service-principals.sh
@@ -6,20 +6,25 @@ TODAY_DATE=$(date +%Y-%m-%d)
 
 CHECK_DATE=$(date -d "+${CHECK_DAYS} days" +%Y-%m-%d)
 
+DOMAIN=$(az rest --method get --url https://graph.microsoft.com/v1.0/domains --query 'value[?isDefault].id' -o tsv)
 
-AZ_APP_RESULT=$( az ad app list --all --query "[?passwordCredentials[?endDateTime < '${CHECK_DATE}']].{displayName:displayName, appId:appId, createdDateTime:createdDateTime, passwordCredentials:passwordCredentials[?endDateTime < '${CHECK_DATE}'].{displayName:displayName,endDateTime:endDateTime}}" --output json )
-
+if [ $DOMAIN = "HMCTS.NET" ]; then
+    AZ_APP_RESULT=$( az ad app list --all --query "[?passwordCredentials[?endDateTime < '${CHECK_DATE}']].{displayName:displayName, appId:appId, createdDateTime:createdDateTime, passwordCredentials:passwordCredentials[?endDateTime < '${CHECK_DATE}'].{displayName:displayName,endDateTime:endDateTime}}" --output json )
+else
+    AZ_APP_RESULT=$( az ad app list --display-name "DTS Operations Bootstrap GA" --query "[?passwordCredentials[?endDateTime < '${CHECK_DATE}']].{displayName:displayName, appId:appId, createdDateTime:createdDateTime, passwordCredentials:passwordCredentials[?endDateTime < '${CHECK_DATE}'].{displayName:displayName,endDateTime:endDateTime}}" --output json )
 
 AZ_APP_COUNT=$(jq -r '. | length' <<< "${AZ_APP_RESULT}")
 
-printf "\n:azure-826: <https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps|_*Service Principal Secrets Status*_> \n" >> slack-message.txt
+if [ $DOMAIN = "HMCTS.NET" ]; then
+    printf "\n:azure-826: <https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps|_*Service Principal Secrets Status*_> \n" >> slack-message.txt
+else
+    printf "\n:azure-826: <https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps|_*Service Principal Secrets Status - HMCTS Dev Tenant*_> \n" >> slack-message.txt
+fi
 
 if [[ $AZ_APP_COUNT == 0 ]]; then
     printf "\n:green_circle: No Service Principals Secrets are expiring in $CHECK_DAYS days \n\n" >> slack-message.txt
     exit 0
 fi
-
-
 
 echo "$AZ_APP_RESULT" | jq -c -r '.[]'  | while read i; do
     displayName=$(jq -r '.displayName' <<< "$i")

--- a/scripts/service-principals.sh
+++ b/scripts/service-principals.sh
@@ -12,6 +12,7 @@ if [ $DOMAIN = "HMCTS.NET" ]; then
     AZ_APP_RESULT=$( az ad app list --all --query "[?passwordCredentials[?endDateTime < '${CHECK_DATE}']].{displayName:displayName, appId:appId, createdDateTime:createdDateTime, passwordCredentials:passwordCredentials[?endDateTime < '${CHECK_DATE}'].{displayName:displayName,endDateTime:endDateTime}}" --output json )
 else
     AZ_APP_RESULT=$( az ad app list --display-name "DTS Operations Bootstrap GA" --query "[?passwordCredentials[?endDateTime < '${CHECK_DATE}']].{displayName:displayName, appId:appId, createdDateTime:createdDateTime, passwordCredentials:passwordCredentials[?endDateTime < '${CHECK_DATE}'].{displayName:displayName,endDateTime:endDateTime}}" --output json )
+fi
 
 AZ_APP_COUNT=$(jq -r '. | length' <<< "${AZ_APP_RESULT}")
 


### PR DESCRIPTION
Add check for service principal secrets on HMCTS Dev Tenant

Only checks for the one currently in use for the azure-enterprise pipeline.