### PR TITLE
DTSPO-17617 - Account for stopped flex servers

### DIFF
--- a/scripts/postgres-flexible-storage.sh
+++ b/scripts/postgres-flexible-storage.sh
@@ -1,4 +1,4 @@
-set -ex
+set -e
 
 SUBSCRIPTION=$1
 

--- a/scripts/postgres-flexible-storage.sh
+++ b/scripts/postgres-flexible-storage.sh
@@ -1,8 +1,8 @@
-set -e
+set -ex
 
 SUBSCRIPTION=$1
 
-POSTGRES_FLEXIBLE_INSTANCES=$(az postgres flexible-server list --subscription $SUBSCRIPTION --query "[].{id: id, name: name}")
+POSTGRES_FLEXIBLE_INSTANCES=$(az postgres flexible-server list --subscription $SUBSCRIPTION --query "[].{id: id, name: name, state: state}")
 
 printf "\n\n:database: PostgreSQL Flexible Server Storage Usage: $SUBSCRIPTION \n\n" >>slack-message.txt
 
@@ -12,14 +12,19 @@ STORAGE_SAFE_COUNT=0
 for ((INDEX = 0; INDEX < $COUNT; INDEX++)); do
   INSTANCE_ID=$(echo $POSTGRES_FLEXIBLE_INSTANCES | jq -r '.['$INDEX'].id')
   INSTANCE_NAME=$(echo $POSTGRES_FLEXIBLE_INSTANCES | jq -r '.['$INDEX'].name')
-  INSTANCE_URL="https://portal.azure.com/#@HMCTS.NET/resource$INSTANCE_ID"
-  STORAGE_USED=$(az monitor metrics list --resource "$INSTANCE_ID" --metric storage_percent --offset 0d6h --interval 6h | jq -r ".value[0].timeseries[0].data[0].average | round")
-  if [ "$STORAGE_USED" -gt 95 ]; then
-    echo "> :red_circle: <$INSTANCE_URL|_*$INSTANCE_NAME*_> is running above 95% storage capacity at *$STORAGE_USED%*" >>slack-message.txt
-  elif [ "$STORAGE_USED" -gt 80 ]; then
-    echo "> :yellow_circle: <$INSTANCE_URL|_*$INSTANCE_NAME*_> is running above 80% storage capacity at *$STORAGE_USED%*" >>slack-message.txt
+  INSTANCE_STATE=$(echo $POSTGRES_FLEXIBLE_INSTANCES | jq -r '.['$INDEX'].state')
+  if [ "$INSTANCE_STATE" == "Ready" ]; then
+    INSTANCE_URL="https://portal.azure.com/#@HMCTS.NET/resource$INSTANCE_ID"
+    STORAGE_USED=$(az monitor metrics list --resource "$INSTANCE_ID" --metric storage_percent --offset 0d6h --interval 6h | jq -r ".value[0].timeseries[0].data[0].average | round")
+    if [ "$STORAGE_USED" -gt 95 ]; then
+      echo "> :red_circle: <$INSTANCE_URL|_*$INSTANCE_NAME*_> is running above 95% storage capacity at *$STORAGE_USED%*" >>slack-message.txt
+    elif [ "$STORAGE_USED" -gt 80 ]; then
+      echo "> :yellow_circle: <$INSTANCE_URL|_*$INSTANCE_NAME*_> is running above 80% storage capacity at *$STORAGE_USED%*" >>slack-message.txt
+    else
+      STORAGE_SAFE_COUNT=$(($STORAGE_SAFE_COUNT+1))
+    fi
   else
-    STORAGE_SAFE_COUNT=$(($STORAGE_SAFE_COUNT+1))
+    echo "> :red_circle: _*$INSTANCE_NAME*_ is in *$INSTANCE_STATE* state." >>slack-message.txt
   fi
 done
 


### PR DESCRIPTION
### Jira link

See [DTSPO-17617](https://tools.hmcts.net/jira/browse/DTSPO-17617)

### Change description

Flexible server storage checks are failing because a server is currently stopped
Adding some logic to handle this

<img width="605" alt="image" src="https://github.com/user-attachments/assets/93ae992c-3757-495f-8822-abef4594e96b">


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
