### PR TITLE
Update license checks for GitHub and Launch Darkly, update pipeline to add arguments and re-order steps

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -261,12 +261,6 @@ jobs:
             filePath: scripts/ado-pipeline-monitor.sh
             arguments: $(azure-devops-token) ${{ado_pipeline.project}} ${{ado_pipeline.definitionId}}  ${{ado_pipeline.timeForAmber}}  ${{ado_pipeline.timeForRed}}  "${{ado_pipeline.pipelineName}}" "${{ado_pipeline.branchName}}"
       - task: Bash@3
-        displayName: 'Checking Github Licenses'
-        inputs:
-          targetType: filePath
-          filePath: scripts/github-licenses.sh
-          arguments: $(github-management-api-token)
-      - task: Bash@3
         displayName: 'Github workflow status header'
         inputs:
           targetType: 'inline'
@@ -279,12 +273,6 @@ jobs:
             targetType: filePath
             filePath: scripts/github-scheduled-workflow-monitor.sh
             arguments: $(github-management-api-token) ${{gh_workflow.repo}} ${{gh_workflow.branch}} ${{gh_workflow.run}}
-      - task: Bash@3
-        displayName: "\nChecking Launchdarkly Licenses"
-        inputs:
-          targetType: filePath
-          filePath: scripts/ld-license.sh
-          arguments: $(launchdarkly-access-token)
       - ${{ each cluster in parameters.aks_clusters }}:
         - task: AzureCLI@2
           displayName: 'Get AKS Cluster Status'
@@ -405,3 +393,15 @@ jobs:
             --slackChannelName $(main_channel)
             --snowUsername $(service-now-username)
             --snowPassword $(service-now-password)
+      - task: Bash@3
+        displayName: 'Github Licenses check'
+        inputs:
+          targetType: filePath
+          filePath: scripts/github-licenses.sh
+          arguments: --slackBotToken $(dtspo-daily-checks-slack-bot-token) --slackChannelName $(main_channel) --token $(github-management-api-token)
+      - task: Bash@3
+        displayName: "Launchdarkly Licenses check"
+        inputs:
+          targetType: filePath
+          filePath: scripts/ld-license.sh
+          arguments: --slackBotToken $(dtspo-daily-checks-slack-bot-token) --slackChannelName $(main_channel) --token $(launchdarkly-access-token)

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -27,7 +27,7 @@ slackNotification() {
             --arg username "Plato" \
             --arg icon_emoji ":plato:" \
             --argjson blocks "$headerPayload" \
-            '{channel: $channel, unfurl_links: false, username: $username, blocks: $blocks, icon_emoji: $icon_emoji}')
+            '{channel: $channel, username: $username, blocks: $blocks, icon_emoji: $icon_emoji, unfurl_links: false}')
 
     RESPONSE=$(curl -s -H "Content-Type: application/json" \
     --data "${payload}" \

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -27,7 +27,7 @@ slackNotification() {
             --arg username "Plato" \
             --arg icon_emoji ":plato:" \
             --argjson blocks "$headerPayload" \
-            '{channel: $channel, username: $username, blocks: $blocks, icon_emoji: $icon_emoji}')
+            '{channel: $channel, unfurl_links: false, username: $username, blocks: $blocks, icon_emoji: $icon_emoji}')
 
     RESPONSE=$(curl -s -H "Content-Type: application/json" \
     --data "${payload}" \

--- a/scripts/github-licenses.sh
+++ b/scripts/github-licenses.sh
@@ -1,10 +1,70 @@
-TOKEN=$1
+#!/usr/bin/env bash
 
-RESULT=$(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" \
+# This script will download the latest output from the orphaned resource deletion repository that contains any resources that could not be deleted.
+# This will then be sent to Slack in the Daily Checks channel for easier monitoring by all teams.
+
+### Setup script environment
+set -euo pipefail
+
+# Source central functions script
+source scripts/common-functions.sh
+
+slackBotToken=
+slackChannelName=
+token=
+
+usage(){
+>&2 cat << EOF
+------------------------------------------------
+Script to check GitHub page expiry
+------------------------------------------------
+Usage: $0
+    [ -t | --slackBotToken ]
+    [ -c | --slackChannelName ]
+    [ -n | --token ]
+    [ -h | --help ]
+EOF
+exit 1
+}
+
+args=$(getopt -a -o t:c:n:h: --long slackBotToken:,slackChannelName:token:,help -- "$@")
+if [[ $? -gt 0 ]]; then
+    usage
+fi
+
+eval set -- ${args}
+while :
+do
+    case $1 in
+        -h | --help)              usage                    ; shift   ;;
+        -t | --slackBotToken)     slackBotToken=$2         ; shift 2 ;;
+        -c | --slackChannelName)  slackChannelName=$2      ; shift 2 ;;
+        -n | --token)             token=$2                 ; shift 2 ;;
+        # -- means the end of the arguments; drop this, and break out of the while loop
+        --) shift; break ;;
+        *) >&2 echo Unsupported option: $1
+            usage ;;
+    esac
+done
+
+if [[ -z "$slackBotToken" || -z "$slackChannelName" ]]; then
+    {
+        echo "------------------------"
+        echo 'Please supply all of: '
+        echo '- Slack token'
+        echo '- Slack channel name'
+        echo '- token'
+        echo "------------------------"
+    } >&2
+    exit 1
+fi
+
+RESULT=$(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${token}" -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/enterprises/hmcts/consumed-licenses)
-CONSUMED_LICENSES=$(jq -r .total_seats_consumed <<< "${RESULT}")
+
 TOTAL_LICENSES=$(jq -r .total_seats_purchased <<< "${RESULT}")
- 
+CONSUMED_LICENSES=$(jq -r .total_seats_consumed <<< "${RESULT}")
+
 LICENSES_LEFT=$((TOTAL_LICENSES-CONSUMED_LICENSES))
 
 LICENSE_STATUS=":red_circle:"
@@ -16,3 +76,5 @@ fi
 
 printf "\n:github: <https://github.com/orgs/hmcts/people|_*GitHub License Status*_> \n\n" >> slack-message.txt
 printf "> %s *%s* out of *%s* licenses left \n" "$LICENSE_STATUS" "$LICENSES_LEFT" "$TOTAL_LICENSES" >> slack-message.txt
+
+slackNotification $slackBotToken $slackChannelName ":github: $LICENSE_STATUS"  "<https://github.com/orgs/hmcts/people|_*GitHub License Status*_> _*$LICENSES_LEFT*_ out of *"$TOTAL_LICENSES"* licenses left"

--- a/scripts/github-licenses.sh
+++ b/scripts/github-licenses.sh
@@ -77,4 +77,4 @@ fi
 printf "\n:github: <https://github.com/orgs/hmcts/people|_*GitHub License Status*_> \n\n" >> slack-message.txt
 printf "> %s *%s* out of *%s* licenses left \n" "$LICENSE_STATUS" "$LICENSES_LEFT" "$TOTAL_LICENSES" >> slack-message.txt
 
-slackNotification $slackBotToken $slackChannelName ":github: $LICENSE_STATUS"  "<https://github.com/orgs/hmcts/people|_*GitHub License Status*_> _*$LICENSES_LEFT*_ out of *"$TOTAL_LICENSES"* licenses left"
+slackNotification $slackBotToken $slackChannelName ":github: $LICENSE_STATUS GitHub License Check"  "<https://github.com/orgs/hmcts/people|_*GitHub Licenses*_> _*$LICENSES_LEFT*_ out of *"$TOTAL_LICENSES"* licenses left"

--- a/scripts/github-licenses.sh
+++ b/scripts/github-licenses.sh
@@ -27,7 +27,7 @@ EOF
 exit 1
 }
 
-args=$(getopt -a -o t:c:n:h: --long slackBotToken:,slackChannelName:token:,help -- "$@")
+args=$(getopt -a -o t:c:n:h: --long slackBotToken:,slackChannelName:,token:,help -- "$@")
 if [[ $? -gt 0 ]]; then
     usage
 fi

--- a/scripts/ld-license.sh
+++ b/scripts/ld-license.sh
@@ -73,4 +73,4 @@ elif ((  "$LICENSES_LEFT" >= 10 )); then
   LICENSE_STATUS=":yellow_circle:"
 fi
 
-slackNotification $slackBotToken $slackChannelName ":launchdarkly: $LICENSE_STATUS"  "<https://app.launchdarkly.com/settings/members|_*LaunchDarkly License Status*_> _*$LICENSES_LEFT*_ out of *"$TOTAL_LICENSES"* licenses left"
+slackNotification $slackBotToken $slackChannelName ":launchdarkly: $LICENSE_STATUS"  "<https://app.launchdarkly.com/settings/members|_*LaunchDarkly License Status*_> _*$LICENSES_LEFT*_ out of *$TOTAL_LICENSES* licenses left"

--- a/scripts/ld-license.sh
+++ b/scripts/ld-license.sh
@@ -1,10 +1,69 @@
-TOKEN=$1
-set -ex
+#!/usr/bin/env bash
 
-RESULT=$(curl -X GET https://app.launchdarkly.com/api/v2/members -H "Authorization: ${TOKEN}")
+# This script will download the latest output from the orphaned resource deletion repository that contains any resources that could not be deleted.
+# This will then be sent to Slack in the Daily Checks channel for easier monitoring by all teams.
+
+### Setup script environment
+set -euo pipefail
+
+# Source central functions script
+source scripts/common-functions.sh
+
+slackBotToken=
+slackChannelName=
+token=
+
+usage(){
+>&2 cat << EOF
+------------------------------------------------
+Script to check GitHub page expiry
+------------------------------------------------
+Usage: $0
+    [ -t | --slackBotToken ]
+    [ -c | --slackChannelName ]
+    [ -n | --token ]
+    [ -h | --help ]
+EOF
+exit 1
+}
+
+args=$(getopt -a -o t:c:n:h: --long slackBotToken:,slackChannelName:token:,help -- "$@")
+if [[ $? -gt 0 ]]; then
+    usage
+fi
+
+eval set -- ${args}
+while :
+do
+    case $1 in
+        -h | --help)              usage                    ; shift   ;;
+        -t | --slackBotToken)     slackBotToken=$2         ; shift 2 ;;
+        -c | --slackChannelName)  slackChannelName=$2      ; shift 2 ;;
+        -n | --token)             token=$2                 ; shift 2 ;;
+        # -- means the end of the arguments; drop this, and break out of the while loop
+        --) shift; break ;;
+        *) >&2 echo Unsupported option: $1
+            usage ;;
+    esac
+done
+
+if [[ -z "$slackBotToken" || -z "$slackChannelName" ]]; then
+    {
+        echo "------------------------"
+        echo 'Please supply all of: '
+        echo '- Slack token'
+        echo '- Slack channel name'
+        echo '- token'
+        echo "------------------------"
+    } >&2
+    exit 1
+fi
+
+
+RESULT=$(curl -X GET https://app.launchdarkly.com/api/v2/members -H "Authorization: ${token}")
 CONSUMED_LICENSES=$(jq -r .totalCount <<< "${RESULT}")
 TOTAL_LICENSES=150 #None of the public APIs seem to return the number of licenses we have.
- 
+
 LICENSES_LEFT=$((TOTAL_LICENSES-CONSUMED_LICENSES))
 
 LICENSE_STATUS=":red_circle:"
@@ -14,5 +73,4 @@ elif ((  "$LICENSES_LEFT" >= 10 )); then
   LICENSE_STATUS=":yellow_circle:"
 fi
 
-printf "\n\n:launchdarkly: <https://app.launchdarkly.com/settings/members|_*LaunchDarkly License Status*_> \n\n" >> slack-message.txt
-printf "> %s *%s* out of *%s* licenses left \n" "$LICENSE_STATUS" "$LICENSES_LEFT" "$TOTAL_LICENSES" >> slack-message.txt
+slackNotification $slackBotToken $slackChannelName ":launchdarkly: $LICENSE_STATUS"  "<https://app.launchdarkly.com/settings/members|_*LaunchDarkly License Status*_> _*$LICENSES_LEFT*_ out of *"$TOTAL_LICENSES"* licenses left"

--- a/scripts/ld-license.sh
+++ b/scripts/ld-license.sh
@@ -73,4 +73,4 @@ elif ((  "$LICENSES_LEFT" >= 10 )); then
   LICENSE_STATUS=":yellow_circle:"
 fi
 
-slackNotification $slackBotToken $slackChannelName ":launchdarkly: $LICENSE_STATUS"  "<https://app.launchdarkly.com/settings/members|_*LaunchDarkly License Status*_> _*$LICENSES_LEFT*_ out of *$TOTAL_LICENSES* licenses left"
+slackNotification $slackBotToken $slackChannelName ":launchdarkly: $LICENSE_STATUS Launch Darkly License Check"  "<https://app.launchdarkly.com/settings/members|_*LaunchDarkly Licenses*_> _*$LICENSES_LEFT*_ out of *$TOTAL_LICENSES* licenses left"

--- a/scripts/ld-license.sh
+++ b/scripts/ld-license.sh
@@ -27,7 +27,7 @@ EOF
 exit 1
 }
 
-args=$(getopt -a -o t:c:n:h: --long slackBotToken:,slackChannelName:token:,help -- "$@")
+args=$(getopt -a -o t:c:n:h: --long slackBotToken:,slackChannelName:,token:,help -- "$@")
 if [[ $? -gt 0 ]]; then
     usage
 fi


### PR DESCRIPTION
### Change description
Update license checks for GitHub and Launch Darkly
Update pipeline to add arguments and re-order steps

License checks will not use a thread but instead print the status and remaining licenses in a sub-header

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
