### PR TITLE
DTSPO-18687 - adding failed state recheck

### DIFF
--- a/scripts/cluster-state-monitor.sh
+++ b/scripts/cluster-state-monitor.sh
@@ -12,7 +12,7 @@ slackChannelName=
 failedState=()
 
 usage() {
-    cat >&2 <<EOF
+>&2 cat << EOF
     ------------------------------------------------
     Script to check GitHub page expiry
     ------------------------------------------------
@@ -83,7 +83,7 @@ while read cluster; do
 
     if [[ $cluster_status == "Failed" ]]; then
         autoFixCluster $resourceId $cluster_name
-        
+
         #if cluster is still in a failed state after recheck, add to failedState array
         if [[ $cluster_status_recheck == "Failed" ]]; then
             failedState+="\n>:red_circle: <https://portal.azure.com/#@HMCTS.NET/resource$cluster_id|_*$cluster_name*_> has a provisioning state of $cluster_status"

--- a/scripts/cluster-state-monitor.sh
+++ b/scripts/cluster-state-monitor.sh
@@ -11,8 +11,8 @@ slackBotToken=
 slackChannelName=
 failedState=()
 
-usage(){
->&2 cat << EOF
+usage() {
+    cat >&2 <<EOF
     ------------------------------------------------
     Script to check GitHub page expiry
     ------------------------------------------------
@@ -21,7 +21,12 @@ usage(){
         [ -c | --slackChannelName ]
         [ -h | --help ]
 EOF
-exit 1
+    exit 1
+}
+
+autoFixCluster() {
+    az resource update --ids $1
+    cluster_status_recheck=$(az graph query -q "resources | where type =~ 'Microsoft.ContainerService/managedClusters'| where name == '$2'| project properties.provisioningState" -o json)
 }
 
 args=$(getopt -a -o t:c:p:g: --long slackBotToken:,slackChannelName:,help -- "$@")
@@ -30,16 +35,29 @@ if [[ $? -gt 0 ]]; then
 fi
 
 eval set -- ${args}
-while :
-do
+while :; do
     case $1 in
-        -h | --help)              usage                    ; shift   ;;
-        -t | --slackBotToken)     slackBotToken=$2         ; shift 2 ;;
-        -c | --slackChannelName)  slackChannelName=$2      ; shift 2 ;;
-        # -- means the end of the arguments; drop this, and break out of the while loop
-        --) shift; break ;;
-        *) >&2 echo Unsupported option: $1
-            usage ;;
+    -h | --help)
+        usage
+        shift
+        ;;
+    -t | --slackBotToken)
+        slackBotToken=$2
+        shift 2
+        ;;
+    -c | --slackChannelName)
+        slackChannelName=$2
+        shift 2
+        ;;
+    # -- means the end of the arguments; drop this, and break out of the while loop
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo >&2 Unsupported option: $1
+        usage
+        ;;
     esac
 done
 
@@ -55,32 +73,28 @@ if [[ -z "$slackBotToken" || -z "$slackChannelName" ]]; then
     exit 1
 fi
 
-SUBSCRIPTIONS=$(az account list -o json)
+CLUSTERS=$(az graph query -q "resources | where type =~ 'Microsoft.ContainerService/managedClusters'| where tags.application == 'core'| project name, resourceGroup, properties, ['id']" --first 1000 -o json)
 
-while read subscription; do
-    SUBSCRIPTION_ID=$(jq -r '.id' <<< $subscription)
-    az account set -s $SUBSCRIPTION_ID
-    CLUSTERS=$(az resource list --resource-type Microsoft.ContainerService/managedClusters --query "[?tags.application == 'core']" -o json)
+while read cluster; do
+    RESOURCE_GROUP=$(jq -r '.resourceGroup' <<<$cluster)
+    cluster_name=$(jq -r '.name' <<<$cluster)
+    resourceId=$(jq -r '.id' <<<$cluster)
+    cluster_status=$(jq -r '.provisioningState' <<<"$cluster")
 
-    while read cluster; do
-        RESOURCE_GROUP=$(jq -r '.resourceGroup' <<< $cluster)
-        cluster_name=$(jq -r '.name' <<< $cluster)
-
-        cluster_data=$(az aks show -n $cluster_name -g $RESOURCE_GROUP -o json)
-        cluster_status=$(jq -r '.provisioningState' <<< "$cluster_data")
-        cluster_id=$(jq -r '.id' <<< "$cluster_data")
-
-        if [[ $cluster_status == "Failed" ]]; then
+    if [[ $cluster_status == "Failed" ]]; then
+        autoFixCluster $resourceId $cluster_name
+        
+        #if cluster is still in a failed state after recheck, add to failedState array
+        if [[ $cluster_status_recheck == "Failed" ]]; then
             failedState+="\n>:red_circle: <https://portal.azure.com/#@HMCTS.NET/resource$cluster_id|_*$cluster_name*_> has a provisioning state of $cluster_status"
             failures_exist="true"
         fi
-    done < <(jq -c '.[]' <<< $CLUSTERS) # end_of_cluster_loop
-
-done < <(jq -c '.[]' <<< $SUBSCRIPTIONS)
+    fi
+done < <(jq -c '.data[]' <<<$CLUSTERS) # end_of_cluster_loop
 
 # Default to green if the variable doesn't exist
 checkStatus=":green_circle:"
-if [ -n "${failures_exist+x}" ]; then # Check if variable exists
+if [ -n "${failures_exist+x}" ]; then        # Check if variable exists
     if [ "$failures_exist" == "true" ]; then #Check if the value is "true"
         checkStatus=":red_circle:"
     fi


### PR DESCRIPTION
### Jira link

DTSPO-18687

### Change description

- Adding logic to attempt to resolve clusters in a failed state automatically.
- If cluster is still in a failed state after a 'recheck', then flag it as an issue as per current process.
- Moving query to use MS graph, which allows removal of subscription loop for simplification and script efficiency.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
