### PR TITLE
change failing workflow check to lowercase to match file name

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -32,7 +32,7 @@ parameters:
         run: 'aks-auto-shutdown'
       - repo: 'auto-shutdown'
         branch: 'master'
-        run: 'VM-auto-start'
+        run: 'vm-auto-start'
       - repo: 'auto-shutdown'
         branch: 'master'
         run: 'vm-auto-shutdown'


### PR DESCRIPTION
Change failing workflow check to lowercase to match file name in remote repo.