### PR TITLE
Remove green status from backup vault check, only alert for issues

### DIFF
--- a/scripts/dr-backup-vault-monitor.sh
+++ b/scripts/dr-backup-vault-monitor.sh
@@ -124,8 +124,4 @@ if [[ "$activeFailedCount" -gt 0 ]]; then
     slackThreadResponse "$slackBotToken" "$slackChannelName" \
         "$failureText" \
         "$TS"
-else
-    slackNotification "$slackBotToken" "$slackChannelName" \
-        ":green_circle: Azure Backup Vault" \
-        ":azure: No unresolved backup failures in <${vaultURL}|_*${backupVault}*_> :tada:"
 fi


### PR DESCRIPTION
Remove green status from backup vault check, only alert for issues